### PR TITLE
Add Veepeak dongle discovery support

### DIFF
--- a/custom_components/nissan_leaf_obd_ble/config_flow.py
+++ b/custom_components/nissan_leaf_obd_ble/config_flow.py
@@ -16,7 +16,11 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
-LOCAL_NAMES = {"OBDBLE"}
+# Device names to look for when automatically discovering compatible dongles.
+# Some OBD-II dongles, such as the Veepeak BLE model, do not use the
+# "OBDBLE" prefix in their Bluetooth name.  Include them here so that the
+# integration can discover and select them without manual intervention.
+LOCAL_NAMES = {"OBDBLE", "VEEPEAK"}
 
 
 class NissanLeafObdBleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):


### PR DESCRIPTION
## Summary
- allow discovery of Veepeak OBD dongles

## Testing
- `pre-commit run --files custom_components/nissan_leaf_obd_ble/config_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_687dc663abdc832e9541e5dcdfa6d8f7